### PR TITLE
Fix section titles

### DIFF
--- a/javascripts/discourse/connectors/below-footer/custom-footer.js.es6
+++ b/javascripts/discourse/connectors/below-footer/custom-footer.js.es6
@@ -46,6 +46,7 @@ export default {
 
         const listItem = {
           text,
+          title,
           className,
           childLinks
         };


### PR DESCRIPTION
Add missing property to the section object.

After this PR is applied, section labels will have their own titles that are defined in the component settings. Now these titles are completely ignored.

<details>
  <summary><b>Screenshot</b> (Click to expand)</summary>

![image](https://user-images.githubusercontent.com/1119267/111130416-3ff50200-8588-11eb-8520-56f071e06d21.png)
</details>