### PR TITLE
DEV: use dasherize, update user-input classnames to data-attrs

### DIFF
--- a/javascripts/discourse/components/custom-footer.hbs
+++ b/javascripts/discourse/components/custom-footer.hbs
@@ -13,7 +13,10 @@
         <div class="links">
           {{#each this.linkSections as |section|}}
             <div class="list">
-              <span data-name={{section.dataName}} title={{section.title}}>
+              <span
+                data-easyfooter-section={{section.dataName}}
+                title={{section.title}}
+              >
                 {{section.text}}
               </span>
 
@@ -21,7 +24,7 @@
                 {{#each section.childLinks as |link|}}
                   <li
                     class="footer-section-link-wrapper"
-                    data-name={{link.dataName}}
+                    data-easyfooter-link={{link.dataName}}
                   >
                     <a
                       class="footer-section-link"
@@ -43,7 +46,7 @@
           {{#each this.smallLinks as |link|}}
             <a
               class="small-link"
-              data-name={{link.dataName}}
+              data-easyfooter-small-link={{link.dataName}}
               title={{link.title}}
               target={{link.target}}
               href={{link.href}}
@@ -57,7 +60,7 @@
           {{#each this.socialLinks as |link|}}
             <a
               class="social-link"
-              data-name={{link.dataName}}
+              data-easyfooter-social-link={{link.dataName}}
               title={{link.title}}
               target={{link.target}}
               href={{link.href}}

--- a/javascripts/discourse/components/custom-footer.hbs
+++ b/javascripts/discourse/components/custom-footer.hbs
@@ -13,13 +13,16 @@
         <div class="links">
           {{#each this.linkSections as |section|}}
             <div class="list">
-              <span class={{section.className}} title={{section.title}}>
+              <span data-name={{section.dataName}} title={{section.title}}>
                 {{section.text}}
               </span>
 
               <ul>
                 {{#each section.childLinks as |link|}}
-                  <li class="footer-section-link-wrapper {{link.className}}">
+                  <li
+                    class="footer-section-link-wrapper"
+                    data-name={{link.dataName}}
+                  >
                     <a
                       class="footer-section-link"
                       title={{link.title}}
@@ -39,7 +42,8 @@
         <div class="footer-links">
           {{#each this.smallLinks as |link|}}
             <a
-              class="small-link {{link.className}}"
+              class="small-link"
+              data-name={{link.dataName}}
               title={{link.title}}
               target={{link.target}}
               href={{link.href}}
@@ -52,7 +56,8 @@
         <div class="social">
           {{#each this.socialLinks as |link|}}
             <a
-              class="social-link {{link.className}}"
+              class="social-link"
+              data-name={{link.dataName}}
               title={{link.title}}
               target={{link.target}}
               href={{link.href}}

--- a/javascripts/discourse/components/custom-footer.js
+++ b/javascripts/discourse/components/custom-footer.js
@@ -1,8 +1,9 @@
 import Component from "@glimmer/component";
+import { dasherize } from "@ember/string";
 
 // Used instead of dasherize for backwards compatibility with stable
 const getClassName = (text) => {
-  return text.toLowerCase().replace(/\s/g, "-");
+  return `--${dasherize(text)}`;
 };
 
 export default class extends Component {

--- a/javascripts/discourse/components/custom-footer.js
+++ b/javascripts/discourse/components/custom-footer.js
@@ -1,10 +1,6 @@
 import Component from "@glimmer/component";
 import { dasherize } from "@ember/string";
 
-const getClassName = (text) => {
-  return `--${dasherize(text)}`;
-};
-
 export default class extends Component {
   mainHeading = settings.Heading;
   blurb = settings.Blurb;
@@ -15,7 +11,7 @@ export default class extends Component {
       const fragments = link.split(",").map((fragment) => fragment.trim());
       const parent = fragments[0].toLowerCase();
       const text = fragments[1];
-      const className = getClassName(text);
+      const dataName = dasherize(text);
       const href = fragments[2];
       const target = fragments[3] === "blank" ? "_blank" : "";
       const title = fragments[4];
@@ -23,7 +19,7 @@ export default class extends Component {
       return {
         parent,
         text,
-        className,
+        dataName,
         href,
         target,
         title,
@@ -36,14 +32,14 @@ export default class extends Component {
       const fragments = section.split(",").map((fragment) => fragment.trim());
       const parentFor = fragments[0].toLowerCase();
       const text = fragments[0];
-      const className = getClassName(text);
+      const dataName = dasherize(text);
       const childLinks = this.linkArray.filter(
         (link) => link.parent === parentFor
       );
 
       return {
         text,
-        className,
+        dataName,
         childLinks,
       };
     });
@@ -53,13 +49,13 @@ export default class extends Component {
     .map((link) => {
       const fragments = link.split(",").map((fragment) => fragment.trim());
       const text = fragments[0];
-      const className = getClassName(text);
+      const dataName = dasherize(text);
       const href = fragments[1];
       const target = fragments[2] === "blank" ? "_blank" : "";
 
       return {
         text,
-        className,
+        dataName,
         href,
         target,
       };
@@ -70,7 +66,7 @@ export default class extends Component {
     .map((link) => {
       const fragments = link.split(",").map((fragment) => fragment.trim());
       const text = fragments[0];
-      const className = getClassName(text);
+      const dataName = dasherize(text);
       const title = fragments[1];
       const href = fragments[2];
       const target = fragments[3] === "blank" ? "_blank" : "";
@@ -78,7 +74,7 @@ export default class extends Component {
 
       return {
         text,
-        className,
+        dataName,
         title,
         href,
         target,

--- a/javascripts/discourse/components/custom-footer.js
+++ b/javascripts/discourse/components/custom-footer.js
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { dasherize } from "@ember/string";
 
-// Used instead of dasherize for backwards compatibility with stable
 const getClassName = (text) => {
   return `--${dasherize(text)}`;
 };

--- a/test/acceptance/easy-footer-test.js
+++ b/test/acceptance/easy-footer-test.js
@@ -2,7 +2,7 @@ import { visit } from "@ember/test-helpers";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 
-acceptance("easy-footer", function (needs) {
+acceptance("Easy Footer - enabled", function (needs) {
   needs.user();
 
   test("shows the footer", async function (assert) {
@@ -15,5 +15,16 @@ acceptance("easy-footer", function (needs) {
     assert.dom(".below-footer-outlet .second-box .links").exists();
     assert.dom(".below-footer-outlet .third-box .footer-links").exists();
     assert.dom(".below-footer-outlet .third-box .social").exists();
+  });
+});
+
+acceptance("Easy Footer - login required", function (needs) {
+  needs.settings({ login_required: true });
+
+  test("hides the footer on the login required page", async function (assert) {
+    settings.Show_footer_on_login_required_page = false;
+    await visit("/");
+
+    assert.dom(".below-footer-outlet.custom-footer .wrap").doesNotExist();
   });
 });


### PR DESCRIPTION
This utilizes `dasherize` and also moves the class names based on user-input to data-attributes (`data-name`) instead. 

The class name change will cause some regressions, but there's a lot of potential for class name collisions here... for example:

![Screenshot 2023-09-08 at 1 01 09 PM](https://github.com/discourse/Discourse-easy-footer/assets/1681963/6cc7b197-e7ad-4394-a871-5a1de398ce85)

Any link name that happens to be a Discourse class name will have some sort of side-effect. 

Also added a test for the login_required setting. 
