### PR TITLE
DEV: Move settings descriptions into translation file

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,20 @@
+en:
+  theme_metadata:
+    settings:
+      heading:
+        description: "Text for the heading in the footer - you can use your site name for example - Max length 25 characters"
+      blurb:
+        description: "Enter a short blurb about your community - Max length 180 characters"
+      link_sections:
+        description: "Add link sections. The ideal number of sections is six. One item per line in this order:<br> Text, title<br><b>Text:</b> what appears on in the footer<br><b>Title:</b> the text that appears when the item is hovered."
+      links:
+        description: "Add links to link sections. One item per line in this order:<br>Parent, text, URL, target, title, referrer policy<br>It is a good idea to keep the number of links under each section similar<br><b>Parent:</b> the name of the parent section which this link shows under. Use the `text` value from the list above<br><b>Text:</b> the text that shows for this link<br><b>URL:</b> the path this item links to. You can use relative paths as well.<br><b>Target:</b> Choose whether this item will open in a new tab or in the same tab. Use blank to open the link in a new tab, or use self to open it in the same tab.<br><b>Title:</b> the text that shows when the link is hovered.<br/><b>Referrer Policy:</b> the referrer policy to use in the link."
+      small_links:
+        description: "You can add small links at the bottom of the footer like Terms of Service and Privacy. One item per line in this order:<br>Text, URL, target<br><b>Text:</b> The text that shows for the small link<br><b>URL:</b> The path of the link<br><b>Target:</b> Use blank to open the link in a new tab and use self to open it in the same tab"
+      social_links:
+        description: "Enter the social links you'd like to add to the footer in this format:<br> provider, title, URL, target<br><b>Provider:</b> is the name of the provider like Facebook or Twitter<br><b>Title:</b> The text that shows when the link is hovered<br><b>URL:</b> The path you'd like the link to have<br><b>Target:</b> Use blank to open the link in a new tab and use self to open it in the same tab<br><b>Icon:</b> use a FontAwesome5 icon name (brand icons need a 'fab-' prefix)."
+      show_footer_on_login_required_page:
+        description: "Check this setting if you want the footer to be displayed on the login-required page (only applies if your site is private)"
+      svg_icons:
+        description: "List of FontAwesome 5 icons used in the social links setting above."
+

--- a/settings.yml
+++ b/settings.yml
@@ -1,43 +1,28 @@
 heading:
   default: "This is a header"
   max: 25
-  description:
-    en: "Text for the heading in the footer - you can use your site name for example - Max length 25 characters"
 blurb:
   default: "Ius vitae ornatus at, ei mea sumo quot dicant. Ei tale democritum eos, in mea timeam accumsan forensibus. Ei his aperiam suavitate. Et debitis convenire sea, viris dictas latine."
   max: 180
-  description:
-    en: "Enter a short blurb about your community - Max length 180 characters"
 link_sections:
   type: list
   list_type: simple
   default: "Design, Get inspired!|Code, Learn new things!|Business, Start a new career!|Shop, Buy cool stuff!|Community, The latest news about the people you care about!|World, Check out what's happening"
-  description:
-    en: "Add link sections. The ideal number of sections is six. One item per line in this order:<br> Text, title<br><b>Text:</b> what appears on in the footer<br><b>Title:</b> the text that appears when the item is hovered."
 links:
   type: list
   list_type: simple
   default: "Design, Design process, #, blank, Learn the basics|Design, Blog design, #, blank, What makes for a great blog?|Design, Photoshop tutorials, #, blank, Photoshop for beginners|Design, Design trends, #, blank, Stay on top of the current trends!|Code, Wordpress, #, blank, Wordpress code examples|Code, Tools, #, blank, Tools that will make your life easier!|Code, Tutorials, #, blank, Just starting out? We'll guide you through the basics|Business, Blogging, #, blank, Why not start a blog?|Business, Social media, #, blank, Learn how to leverage Social media and make it work for your business|Business, Make money, #, blank, Everyone likes to be paid!|Business, Marketing, #, blank, No business will survive without customers...Here's how to get'em!|Shop, Vectors, #, blank, buy vectors|Shop, Textures, #, blank, buy textures|Shop, UI kits, #, blank, buy UI kits|Shop, PSDs, #, blank, Ready-made PSD's|Community, Your corner, #, blank, Tell us how you feel!|Community, Questions, #, blank, Feel like answering some questions?|Community, Members, #, blank, Say hi to new members|Community, trending, #, blank, Catch up with the latest trending topics!|World, Politics, #, blank, Stay up to date|World, Education, #, blank, The latest research|World, Automotive, #, blank, We cover the latest models!|World, Sports, #, The latest scores|World, Tech, #, Never miss a new gadget"
-  description:
-    en: "Add links to link sections. One item per line in this order:<br>Parent, text, URL, target, title, referrer policy<br>It is a good idea to keep the number of links under each section similar<br><b>Parent:</b> the name of the parent section which this link shows under. Use the `text` value from the list above<br><b>Text:</b> the text that shows for this link<br><b>URL:</b> the path this item links to. You can use relative paths as well.<br><b>Target:</b> Choose whether this item will open in a new tab or in the same tab. Use blank to open the link in a new tab, or use self to open it in the same tab.<br><b>Title:</b> the text that shows when the link is hovered.<br/><b>Referrer Policy:</b> the referrer policy to use in the link."
 small_links:
   type: list
   list_type: simple
   default: "Privacy, #, self|Terms of service, #, self| About, #, self"
-  description:
-    en: "You can add small links at the bottom of the footer like Terms of Service and Privacy. One item per line in this order:<br>Text, URL, target<br><b>Text:</b> The text that shows for the small link<br><b>URL:</b> The path of the link<br><b>Target:</b> Use blank to open the link in a new tab and use self to open it in the same tab"
 social_links:
   type: list
   list_type: simple
   default: "Facebook, Join us on Facebook, #, blank,fab-facebook|Twitter, show some love on Twitter, #, blank,fab-twitter| Youtube, Check out our latest videos on Youtube, #, blank,fab-youtube"
-  description:
-    en: "Enter the social links you'd like to add to the footer in this format:<br> provider, title, URL, target<br><b>Provider:</b> is the name of the provider like Facebook or Twitter<br><b>Title:</b> The text that shows when the link is hovered<br><b>URL:</b> The path you'd like the link to have<br><b>Target:</b> Use blank to open the link in a new tab and use self to open it in the same tab<br><b>Icon:</b> use a FontAwesome5 icon name (brand icons need a 'fab-' prefix)."
 show_footer_on_login_required_page:
   default: true
-  description:
-    en: "Check this setting if you want the footer to be displayed on the login-required page (only applies if your site is private)"
 svg_icons:
   default: "fab-facebook|fab-twitter|fab-youtube"
   type: "list"
   list_type: "compact"
-  description: "List of FontAwesome 5 icons used in the social links setting above. "


### PR DESCRIPTION
This commit moves the description for the theme's settings into
`locales/en.yml`. This follows our theme's best practice listed in
https://meta.discourse.org/t/add-localizable-strings-to-themes-and-theme-components/109867
