### PR TITLE
FIX: Footer not shown when `show_footer_on_login_required_page` is true

### DIFF
--- a/javascripts/discourse/connectors/below-login/show-footer.hbs
+++ b/javascripts/discourse/connectors/below-login/show-footer.hbs
@@ -1,3 +1,3 @@
-{{#if (not (theme-setting "Show_footer_on_login_required_page"))}}
+{{#if (not (theme-setting "show_footer_on_login_required_page"))}}
   {{hide-application-footer}}
 {{/if}}

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -74,7 +74,18 @@ RSpec.describe "Footer", system: true do
     end
   end
 
-  it "should not display the footer to anon users when `Show_footer_on_login_required_page` is false" do
+  it "should display the footer to anon users when `show_footer_on_login_required_page` is true" do
+    SiteSetting.login_required = true
+
+    theme.update_setting(:show_footer_on_login_required_page, true)
+    theme.save!
+
+    visit("/")
+
+    expect(page).to have_css(".below-footer-outlet.custom-footer")
+  end
+
+  it "should not display the footer to anon users when `show_footer_on_login_required_page` is false" do
     SiteSetting.login_required = true
 
     theme.update_setting(:show_footer_on_login_required_page, false)


### PR DESCRIPTION
This is fixes a regression introduced in a7663469b5704f37c2a2e61d669c0f1362f2d9c0
