### PR TITLE
DEV: Migrate `small_links` to new objects setting type

### DIFF
--- a/javascripts/discourse/components/custom-footer.hbs
+++ b/javascripts/discourse/components/custom-footer.hbs
@@ -47,13 +47,12 @@
 
       <div class="third-box">
         <div class="footer-links">
-          {{#each this.smallLinks as |link|}}
+          {{#each (theme-setting "small_links") as |link|}}
             <a
               class="small-link"
-              data-easyfooter-small-link={{link.dataName}}
-              title={{link.title}}
+              data-easyfooter-small-link={{dasherize link.text}}
               target={{link.target}}
-              href={{link.href}}
+              href={{link.url}}
             >
               {{link.text}}
             </a>

--- a/javascripts/discourse/components/custom-footer.js
+++ b/javascripts/discourse/components/custom-footer.js
@@ -5,24 +5,6 @@ export default class extends Component {
   mainHeading = settings.heading;
   blurb = settings.blurb;
 
-  smallLinks = settings.small_links
-    .split("|")
-    .filter(Boolean)
-    .map((link) => {
-      const fragments = link.split(",").map((fragment) => fragment.trim());
-      const text = fragments[0];
-      const dataName = dasherize(text);
-      const href = fragments[1];
-      const target = fragments[2] === "blank" ? "_blank" : "";
-
-      return {
-        text,
-        dataName,
-        href,
-        target,
-      };
-    });
-
   socialLinks = settings.social_links
     .split("|")
     .filter(Boolean)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -32,12 +32,20 @@ en:
                 label: Referrer Policy
                 description: The referrerpolicy attribute of the link
 
-      link_sections:
-        description: "Add link sections. The ideal number of sections is six. One item per line in this order:<br> Text, title<br><b>Text:</b> what appears on in the footer<br><b>Title:</b> the text that appears when the item is hovered."
-      links:
-        description: "Add links to link sections. One item per line in this order:<br>Parent, text, URL, target, title, referrer policy<br>It is a good idea to keep the number of links under each section similar<br><b>Parent:</b> the name of the parent section which this link shows under. Use the `text` value from the list above<br><b>Text:</b> the text that shows for this link<br><b>URL:</b> the path this item links to. You can use relative paths as well.<br><b>Target:</b> Choose whether this item will open in a new tab or in the same tab. Use blank to open the link in a new tab, or use self to open it in the same tab.<br><b>Title:</b> the text that shows when the link is hovered.<br/><b>Referrer Policy:</b> the referrer policy to use in the link."
       small_links:
-        description: "You can add small links at the bottom of the footer like Terms of Service and Privacy. One item per line in this order:<br>Text, URL, target<br><b>Text:</b> The text that shows for the small link<br><b>URL:</b> The path of the link<br><b>Target:</b> Use blank to open the link in a new tab and use self to open it in the same tab"
+        description: "Small links at the bottom of the footer like Terms of Service and Privacy"
+        schema:
+          properties:
+            text:
+              label: Text
+              description: Text to be displayed for the link
+            url:
+              label: URL
+              description: The URL the link points to
+            target:
+              label: Target
+              description: The target attribute of the link
+
       social_links:
         description: "Enter the social links you'd like to add to the footer in this format:<br> provider, title, URL, target<br><b>Provider:</b> is the name of the provider like Facebook or Twitter<br><b>Title:</b> The text that shows when the link is hovered<br><b>URL:</b> The path you'd like the link to have<br><b>Target:</b> Use blank to open the link in a new tab and use self to open it in the same tab<br><b>Icon:</b> use a FontAwesome5 icon name (brand icons need a 'fab-' prefix)."
       show_footer_on_login_required_page:

--- a/migrations/settings/0003-migrate-small-links-setting.js
+++ b/migrations/settings/0003-migrate-small-links-setting.js
@@ -1,0 +1,37 @@
+export default function migrate(settings, helpers) {
+  const oldSmallLinks = settings.get("small_links");
+
+  if (oldSmallLinks) {
+    const newSmallLinks = [];
+
+    oldSmallLinks.split("|").forEach((link) => {
+      const [linkText, linkUrl, linkTarget] = link
+        .split(",")
+        .map((fragment) => fragment.trim());
+
+      if (linkText) {
+        const newSmallLink = {
+          text: linkText.substring(0, 1000),
+        };
+
+        if (linkUrl && helpers.isValidUrl(linkUrl) && linkUrl.length <= 2048) {
+          newSmallLink.url = linkUrl;
+        } else {
+          newSmallLink.url = "#";
+        }
+
+        if (linkTarget === "self") {
+          newSmallLink.target = "_self";
+        } else {
+          newSmallLink.target = "_blank";
+        }
+
+        newSmallLinks.push(newSmallLink);
+      }
+    });
+
+    settings.set("small_links", newSmallLinks);
+  }
+
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -158,9 +158,42 @@ sections:
                 - unsafe-url
 
 small_links:
-  type: list
-  list_type: simple
-  default: "Privacy, #, self|Terms of service, #, self| About, #, self"
+  type: objects
+  default:
+    - text: Privacy
+      url: "#"
+      target: _blank
+    - text: Terms of service
+      url: "#"
+      target: _blank
+    - text: About
+      url: "#"
+      target: _blank
+  schema:
+    name: small link
+    identifier: text
+    properties:
+      text:
+        type: string
+        required: true
+        validations:
+          min: 1
+          max: 1000
+      url:
+        type: string
+        required: true
+        validations:
+          min: 1
+          max: 2048
+          url: true
+      target:
+        type: enum
+        default: _blank
+        choices:
+          - _blank
+          - _self
+          - _parent
+          - _top
 
 social_links:
   type: list

--- a/spec/migrations/0003_migrate_small_links_setting_spec.rb
+++ b/spec/migrations/0003_migrate_small_links_setting_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe "0003-migrate-small-links-setting migration" do
+  let!(:theme) { upload_theme_component }
+
+  it "should set target property to `_blank` if previous target component is not valid or empty" do
+    theme.theme_settings.create!(
+      name: "small_links",
+      theme: theme,
+      data_type: ThemeSetting.types[:string],
+      value: "some text, #|some text 2, #, invalid target",
+    )
+
+    run_theme_migration(theme, "0003-migrate-small-links-setting")
+
+    expect(theme.settings[:small_links].value).to eq(
+      [
+        { "text" => "some text", "url" => "#", "target" => "_blank" },
+        { "text" => "some text 2", "url" => "#", "target" => "_blank" },
+      ],
+    )
+  end
+
+  it "should set URL property to `#` if previous URL component is not valid, empty or more than 2048 chars" do
+    theme.theme_settings.create!(
+      name: "small_links",
+      theme: theme,
+      data_type: ThemeSetting.types[:string],
+      value: "some text, not a valid URL|some text 2,,,|some text 3, #|some text 4, #{"a" * 2049}",
+    )
+
+    run_theme_migration(theme, "0003-migrate-small-links-setting")
+
+    expect(theme.settings[:small_links].value).to eq(
+      [
+        { "text" => "some text", "url" => "#", "target" => "_blank" },
+        { "text" => "some text 2", "url" => "#", "target" => "_blank" },
+        { "text" => "some text 3", "url" => "#", "target" => "_blank" },
+        { "text" => "some text 4", "url" => "#", "target" => "_blank" },
+      ],
+    )
+  end
+
+  it "should truncate text property to 1000 chars if previous text property is more than 1000 chars" do
+    theme.theme_settings.create!(
+      name: "small_links",
+      theme: theme,
+      data_type: ThemeSetting.types[:string],
+      value: "#{"a" * 1001}, /some/url",
+    )
+
+    run_theme_migration(theme, "0003-migrate-small-links-setting")
+
+    expect(theme.settings[:small_links].value).to eq(
+      [{ "text" => "#{"a" * 1000}", "url" => "/some/url", "target" => "_blank" }],
+    )
+  end
+
+  it "should not migrate small links setting if text component does not exist" do
+    theme.theme_settings.create!(
+      name: "small_links",
+      theme: theme,
+      data_type: ThemeSetting.types[:string],
+      value: ",/some/url|,,,|some text,/some/url",
+    )
+
+    run_theme_migration(theme, "0003-migrate-small-links-setting")
+
+    expect(theme.settings[:small_links].value).to eq(
+      [{ "text" => "some text", "url" => "/some/url", "target" => "_blank" }],
+    )
+  end
+
+  it "should migrate the small links setting to objects type correctly" do
+    theme.theme_settings.create!(
+      name: "small_links",
+      theme: theme,
+      data_type: ThemeSetting.types[:string],
+      value: "some text,/some/url,blank|some text 2,/some/url2,self|",
+    )
+
+    run_theme_migration(theme, "0003-migrate-small-links-setting")
+
+    expect(theme.settings[:small_links].value).to eq(
+      [
+        { "text" => "some text", "url" => "/some/url", "target" => "_blank" },
+        { "text" => "some text 2", "url" => "/some/url2", "target" => "_self" },
+      ],
+    )
+  end
+end


### PR DESCRIPTION
This commit migrates the `small_links` theme setting to `type: objects`. Since https://github.com/discourse/discourse/commit/a440e15291e98a866f80a6566d5ec0597ab77e2e, we have started to support objects typed theme setting so we are switching this theme component to use it instead as it provides a much better UX for configuring the settings required for the theme component.
