### PR TITLE
FIX: Make title for sections and links optional

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -111,7 +111,6 @@ sections:
           max_length: 1000
       title:
         type: string
-        required: true
         validations:
           min_length: 1
           max_length: 1000
@@ -143,7 +142,6 @@ sections:
                 - _top
             title:
               type: string
-              required: true
               validations:
                 min_length: 1
                 max_length: 1000


### PR DESCRIPTION
The "title" attribute pre-migration was optional so it should stay
optional otherwise migrations can fail
