### PR TITLE
DEV: Handle empty strings for `small_links` migration

### DIFF
--- a/migrations/settings/0003-migrate-small-links-setting.js
+++ b/migrations/settings/0003-migrate-small-links-setting.js
@@ -31,6 +31,8 @@ export default function migrate(settings, helpers) {
     });
 
     settings.set("small_links", newSmallLinks);
+  } else if (oldSmallLinks?.trim() === "") {
+    settings.set("small_links", []);
   }
 
   return settings;

--- a/spec/migrations/0003_migrate_small_links_setting_spec.rb
+++ b/spec/migrations/0003_migrate_small_links_setting_spec.rb
@@ -3,6 +3,19 @@
 RSpec.describe "0003-migrate-small-links-setting migration" do
   let!(:theme) { upload_theme_component }
 
+  it "should handle an empty string for old setting" do
+    theme.theme_settings.create!(
+      name: "small_links",
+      theme:,
+      data_type: ThemeSetting.types[:string],
+      value: "    ",
+    )
+
+    run_theme_migration(theme, "0003-migrate-small-links-setting")
+
+    expect(theme.settings[:small_links].value).to eq([])
+  end
+
   it "should set target property to `_blank` if previous target component is not valid or empty" do
     theme.theme_settings.create!(
       name: "small_links",


### PR DESCRIPTION
Follow up to 105b001d9f662333ff2925514c3c2e930fb2de00
