### PR TITLE
DEV: actually test the footer is rendered

### DIFF
--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -112,17 +112,34 @@ RSpec.describe "Footer", system: true do
 
     visit("/")
 
-    expect(page).to have_css(".below-footer-outlet.custom-footer")
+    expect(page).to have_css(".below-footer-outlet.custom-footer .wrap")
   end
 
   it "should not display the footer to anon users when `show_footer_on_login_required_page` is false" do
     SiteSetting.login_required = true
 
     theme.update_setting(:show_footer_on_login_required_page, false)
+    theme.update_setting(
+      :sections,
+      [
+        {
+          text: "Section 1",
+          title: "Section 1 title",
+          links: [
+            {
+              text: "Section 1 Link",
+              url: "http://some.url.com/section1/link1",
+              title: "Section 1 Link Title",
+              referrer_policy: "origin",
+            },
+          ],
+        },
+      ],
+    )
     theme.save!
 
     visit("/")
 
-    expect(page).not_to have_css(".below-footer-outlet.custom-footer")
+    expect(page).to have_no_css(".below-footer-outlet.custom-footer .wrap")
   end
 end


### PR DESCRIPTION
This test was working by luck in the past, but it was not actually checking if the connector had something rendered inside. We now ensure we have content in both cases and that's not rendered when it shouldn't.