### PR TITLE
FEATURE: Add css class field to small links

### DIFF
--- a/javascripts/discourse/components/custom-footer.gjs
+++ b/javascripts/discourse/components/custom-footer.gjs
@@ -7,6 +7,10 @@ export default class extends Component {
   mainHeading = settings.heading;
   blurb = settings.blurb;
 
+  getLinkClasses(link) {
+    return `small-link${link.css_class ? ` ${link.css_class}` : ''}`;
+  }
+
   <template>
     {{#if @showFooter}}
       <div class="wrap">
@@ -59,7 +63,7 @@ export default class extends Component {
             <div class="footer-links">
               {{#each settings.small_links as |link|}}
                 <a
-                  class="small-link"
+                  class={{this.getLinkClasses link}}
                   data-easyfooter-small-link={{dasherize link.text}}
                   target={{link.target}}
                   href={{link.url}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -45,6 +45,9 @@ en:
             target:
               label: Target
               description: The target attribute of the link
+            css_class:
+              label: CSS Class
+              description: Optional additional CSS class to apply to the link (e.g., 'custom-class')
 
       social_links:
         description: "Social links you'd like to add to the footer"

--- a/settings.yml
+++ b/settings.yml
@@ -102,6 +102,11 @@ small_links:
           - _self
           - _parent
           - _top
+      css_class:
+        type: string
+        validations:
+          min: 1
+          max: 200
 
 social_links:
   type: objects

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -142,4 +142,36 @@ RSpec.describe "Footer", system: true do
 
     expect(page).to have_no_css(".below-footer-outlet.custom-footer .wrap")
   end
+
+  it "should apply css_class to small links when specified" do
+    theme.update_setting(
+      :small_links,
+      [
+        {
+          text: "Privacy",
+          url: "#",
+          target: "_blank",
+        },
+        {
+          text: "Terms",
+          url: "https://example.com/terms",
+          target: "_blank",
+          css_class: "custom-class",
+        },
+      ],
+    )
+    theme.save!
+
+    visit("/")
+
+    within(".below-footer-outlet .footer-links") do
+      # Privacy link should only have the default small-link class
+      expect(page).to have_css("a.small-link[href='#'][target='_blank']", text: "Privacy")
+      expect(page).to have_no_css("a.small-link.custom-class", text: "Privacy")
+
+
+      # Terms link should have both small-link and custom-class classes
+      expect(page).to have_css("a.small-link.custom-class[href='https://example.com/terms'][target='_blank']", text: "Terms")
+    end
+  end
 end


### PR DESCRIPTION
It's possible that you need to interact with a third party js library so
we are adding the ability to add custom css class to the small links
section so that the urls have a class you can add to them and hook off
of.

```
<a class="small-link custom-class" data-easyfooter-small-link="small-link-name" target="_self" href="#link-url">
  Small Link Name
</a>
```
